### PR TITLE
fix UndefinedMethodException?

### DIFF
--- a/Form/Traits/CreateFilterCriteria.php
+++ b/Form/Traits/CreateFilterCriteria.php
@@ -18,7 +18,7 @@ trait CreateFilterCriteria
         foreach ($form as $child) {
             $field = $child->getName();
             $fieldPath = str_replace('_', '.', $field);
-            switch ($child->getConfig()->getType()->getName()) {
+            switch ($child->getConfig()->getType()->getBlockPrefix()) {
                 case 'text':
                     if ($child->getData()) {
                         $criteria[$fieldPath . ' LIKE'] = '%' . $child->getData() . '%';


### PR DESCRIPTION
Attempted to call an undefined method named "getName" of class "Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeDataCollectorProxy".
500 Internal Server Error - UndefinedMethodException
”
Stack Trace
in vendor/ctrl-f5/ctrl-rad-bundle/Form/Traits/CreateFilterCriteria.php at line 21   -
        foreach ($form as $child) {
            $field = $child->getName();
            $fieldPath = str_replace('_', '.', $field);
            switch ($child->getConfig()->getType()->getName()) {
                case 'text':
                    if ($child->getData()) {
                        $criteria[$fieldPath . ' LIKE'] = '%' . $child->getData() . '%';