### PR TITLE
fix login page

### DIFF
--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -13,7 +13,7 @@
                     <div class="panel-body">
 
                         {% if error %}
-                            <div>{{ error|trans({}, 'FOSUserBundle') }}</div>
+                            <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
                         {% endif %}
 
 


### PR DESCRIPTION
[BC break] The FOSUserBundle:Security:login.html.twig template now receives an AuthenticationException in the error variable rather than an error message.